### PR TITLE
Use promise queues and batch writes for speed

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "cli-color": "^2.0.3",
     "eslint-import-resolver-node": "^0.3.7",
     "fs-extra": "^11.1.1",
+    "p-queue-cjs": "^7.3.4",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/src/libs/deepDiff.ts
+++ b/src/libs/deepDiff.ts
@@ -1,0 +1,43 @@
+import _ = require("lodash")
+
+/**
+ * Deep diff between two object-likes
+ * @param  {Object} fromObject the original object
+ * @param  {Object} toObject   the updated object
+ * @return {Object}            a new object which represents the diff
+ */
+export function deepDiff(fromObject: Record<string, any> | object, toObject: Record<string, any>) {
+  const changes: Record<string, any> = {}
+
+  const buildPath = (path: string | undefined, _obj: unknown, key: string) =>
+    _.isUndefined(path) ? key : `${path}.${key}`
+
+  const walk = (fromObject: object | Record<string, any>, toObject: Record<string, any>, path?: string) => {
+    for (const key of _.keys(fromObject)) {
+      const currentPath: string = buildPath(path, fromObject, key)
+      if (!_.has(toObject, key)) {
+        changes[currentPath] = { from: _.get(fromObject, key) }
+      }
+    }
+
+    for (const [key, to] of _.entries(toObject)) {
+      const currentPath = buildPath(path, toObject, key)
+      if (!_.has(fromObject, key)) {
+        changes[currentPath] = { to }
+      } else {
+        const from = _.get(fromObject, key)
+        if (!_.isEqual(from, to)) {
+          if (_.isObjectLike(to) && _.isObjectLike(from)) {
+            walk(from, to, currentPath)
+          } else {
+            changes[currentPath] = { from, to }
+          }
+        }
+      }
+    }
+  }
+
+  walk(fromObject, toObject)
+
+  return changes
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,7 @@
     "strict": true,
     "target": "es2019"
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3305,7 +3305,7 @@ event-emitter@^0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
-eventemitter3@^4.0.4:
+eventemitter3@^4.0.4, eventemitter3@^4.0.7:
   version "4.0.7"
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -5326,6 +5326,14 @@ p-map@^4.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
+p-queue-cjs@^7.3.4:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/p-queue-cjs/-/p-queue-cjs-7.3.4.tgz#22b64de6dff9e0eff63cd8a1e4cd2aa6fe2e7009"
+  integrity sha512-vP0BvEAgmUEShxWBCETvxiUDnwSiCLfBRqmhdKlNvcXF/7x2yemtYLcxT1pfYELZLlyGL3grvGnq+KF5OwNZfA==
+  dependencies:
+    eventemitter3 "^4.0.7"
+    p-timeout-cjs "^5.0.5"
+
 p-queue@^6.6.2:
   version "6.6.2"
   resolved "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz"
@@ -5333,6 +5341,11 @@ p-queue@^6.6.2:
   dependencies:
     eventemitter3 "^4.0.4"
     p-timeout "^3.2.0"
+
+p-timeout-cjs@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/p-timeout-cjs/-/p-timeout-cjs-5.0.5.tgz#20402f1d13112be39ea1a8bccfc57b416c62b44a"
+  integrity sha512-tjXKZjvzLUGerHxY0+hf0XROyF2XtuZpLNtUlkOOW+nVjDIoH0pKi3hh4X4+MXLqYavcIITLjNC0GZHUCRrwpA==
 
 p-timeout@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
* Allows transformations to specify additional options: `scanParams` function to return additional scan options like `FilterExpression`,  `serializeSkip` getter should return true if the `skip` function should be run serially due to heavy async work, `serializeForward` getter should return true if the `forward` function should be run serially due to heavy async work
* Uses `p-queue` (well, the CommonJS fork `p-queue-cjs`) to parallelize scan reads and batch writes
* Skips record update if the transformed output is identical to the scanned item (uses `_.isEqual`)
* Logs item diffs